### PR TITLE
Add test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+*.json
 
 ### STS ###
 .apt_generated

--- a/scripts/create_test_descriptors.sh
+++ b/scripts/create_test_descriptors.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+# Before using ths script you must run the generate_test_private_keys.sh script
+# to set the created values in the parent shell use the command:
+# source create_test_descriptors.sh
+
+# Extract the XPRV values from the key json files
+export ALICE_ROOT_XPRV=$(cat alice-key.json | jq -r '.xprv')
+export BOB_ROOT_XPRV=$(cat bob-key.json | jq -r '.xprv')
+export CAROL_ROOT_XPRV=$(cat carol-key.json | jq -r '.xprv')
+
+# Derive the XPRV values for the BIP84 key path and the ROOT XPRV values
+export ALICE_XPRV=$(bdk-cli key derive --xprv $ALICE_ROOT_XPRV --path "m/84'/1'/0'/0" | jq -r ".xprv")
+export BOB_XPRV=$(bdk-cli key derive --xprv $BOB_ROOT_XPRV --path "m/84'/1'/0'/0" | jq -r ".xprv")
+export CAROL_XPRV=$(bdk-cli key derive --xprv $CAROL_ROOT_XPRV --path "m/84'/1'/0'/0" | jq -r ".xprv")
+
+# Derive the XPUB values for the BIP84 key path and the ROOT XPRV values
+export ALICE_XPUB=$(bdk-cli key derive --xprv $ALICE_ROOT_XPRV --path "m/84'/1'/0'/0" | jq -r ".xpub")
+export BOB_XPUB=$(bdk-cli key derive --xprv $BOB_ROOT_XPRV --path "m/84'/1'/0'/0" | jq -r ".xpub")
+export CAROL_XPUB=$(bdk-cli key derive --xprv $CAROL_ROOT_XPRV --path "m/84'/1'/0'/0" | jq -r ".xpub")
+
+export SHARED_DESCRIPTOR=$(bdk-cli compile "thresh(2,pk($ALICE_XPUB),pk($BOB_XPUB),pk($CAROL_XPUB))" -t "wsh" | jq -r ".descriptor")
+#echo -e "SHARED_DESCRIPTOR=\"$SHARED_DESCRIPTOR\"\n"
+
+export ALICE_SIGNING_DESCRIPTOR=$(bdk-cli compile "thresh(2,pk($ALICE_XPRV),pk($BOB_XPUB),pk($CAROL_XPUB))" -t "wsh" | jq -r ".descriptor")
+#echo -e "ALICE_SIGNING_DESCRIPTOR=\"$ALICE_SIGNING_DESCRIPTOR\"\n"
+
+export BOB_SIGNING_DESCRIPTOR=$(bdk-cli compile "thresh(2,pk($ALICE_XPUB),pk($BOB_XPRV),pk($CAROL_XPUB))" -t "wsh" | jq -r ".descriptor")
+#echo -e "BOB_SIGNING_DESCRIPTOR=\"$BOB_SIGNING_DESCRIPTOR\"\n"
+
+export CAROL_SIGNING_DESCRIPTOR=$(bdk-cli compile "thresh(2,pk($ALICE_XPUB),pk($BOB_XPUB),pk($CAROL_XPRV))" -t "wsh" | jq -r ".descriptor")
+#echo -e "CAROL_SIGNING_DESCRIPTOR=\"$CAROL_SIGNING_DESCRIPTOR\"\n"
+echo done!

--- a/scripts/generate_test_private_keys.sh
+++ b/scripts/generate_test_private_keys.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+# Before using ths script you must install the bdk-cli tool with the command:
+# cargo install bdk-cli --features esplora-ureq,compiler
+
+# Generate three sets of mnemonic seed words and corresponding private keys
+bdk-cli key generate > alice-key.json
+bdk-cli key generate > bob-key.json
+bdk-cli key generate > carol-key.json
+echo done!


### PR DESCRIPTION
Add scripts to generate test keys and from these create test descriptors.

1. install rust `cargo` tool
   https://doc.rust-lang.org/cargo/getting-started/installation.html
2. Install the `bdk-cli` tool
    ```shell
    cargo install bdk-cli --features esplora-ureq,compiler
    ```
4. Run the scripts
    ```shell
    cd scripts
    ./generate_test_private_keys.sh
    source ./create_test_descriptors.sh
    echo $SHARED_DESCRIPTOR
    echo $ALICE_SIGNING_DESCRIPTOR
    echo $BOB_SIGNING_DESCRIPTOR
    echo $CAROL_SIGNING_DESCRIPTOR
    ```
5. Use wallet with the shared descriptor
    ```shell
    bdk-cli wallet -d $SHARED_DESCRIPTOR sync
    bdk-cli wallet -d $SHARED_DESCRIPTOR get_balance
    bdk-cli wallet -d $SHARED_DESCRIPTOR get_new_address
    # Sent testnet coins to new address
    # wait for a confirmation
    bdk-cli wallet -d $SHARED_DESCRIPTOR sync
    bdk-cli wallet -d $SHARED_DESCRIPTOR get_balance
    ```