### PR TITLE
API: Open_Wallet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,14 @@ repositories {
     mavenCentral()
 }
 
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.bitcoindevkit:bdk-jvm:0.3.2")
+    implementation ("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
@@ -2,11 +2,10 @@ package org.bitcoindevkit.karavan
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.http.HttpStatus
-import org.springframework.web.server.ResponseStatusException
 import org.bitcoindevkit.*
 import org.springframework.web.bind.annotation.*
 import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
 @SpringBootApplication
@@ -18,7 +17,7 @@ fun main(args: Array<String>) {
 
 @RestController
 @RequestMapping("/wallet")
-class WalletController() {
+class WalletController(val walletService: WalletService) {
 
     // TODO remove this example
     @GetMapping("/hello/{name}")
@@ -35,19 +34,11 @@ class WalletController() {
         return "hello $name, your new address is $newAddress"
     }
 
-    @PutMapping("/open-wallet")
-    fun setCookie(response: HttpServletResponse, @RequestBody descriptor:String): String? {
-        // create a cookie
-        val cookie = Cookie("wallet", descriptor) // might need to change to springframework cookie instead of java
-        cookie.isHttpOnly = true
+    @PutMapping("/open_wallet")
+    fun openWallet(response: HttpServletResponse, request: HttpServletRequest, @RequestBody payload: Wallet): String? {
 
-        //add cookie to response
-        response.addCookie(cookie)
-        return "Wallet Value Set!"
+        walletService.openWallet(response, payload)
+        return walletService.readCookie(request, "wallet")
     }
 
-    @GetMapping("/read-cookie")
-    fun readCookie(@CookieValue(value = "wallet", defaultValue = "na") descriptor: String): String? {
-        return "My wallet value is $descriptor"
-    }
 }

--- a/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
@@ -3,12 +3,11 @@ package org.bitcoindevkit.karavan
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import org.bitcoindevkit.*
+import org.springframework.web.bind.annotation.*
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletResponse
 
 @SpringBootApplication
 class Karavan
@@ -34,5 +33,21 @@ class WalletController() {
         val wallet = OnlineWallet(descriptor, null, Network.TESTNET, db, client)
         val newAddress = wallet.getNewAddress()
         return "hello $name, your new address is $newAddress"
+    }
+
+    @PutMapping("/open-wallet")
+    fun setCookie(response: HttpServletResponse, @RequestBody descriptor:String): String? {
+        // create a cookie
+        val cookie = Cookie("wallet", descriptor) // might need to change to springframework cookie instead of java
+        cookie.isHttpOnly = true
+
+        //add cookie to response
+        response.addCookie(cookie)
+        return "Wallet Value Set!"
+    }
+
+    @GetMapping("/read-cookie")
+    fun readCookie(@CookieValue(value = "wallet", defaultValue = "na") descriptor: String): String? {
+        return "My wallet value is $descriptor"
     }
 }

--- a/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
@@ -1,12 +1,19 @@
 package org.bitcoindevkit.karavan
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.bitcoindevkit.*
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.bitcoindevkit.*
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.util.WebUtils
+import java.util.*
+import java.util.stream.Collectors
 import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import kotlin.reflect.full.memberProperties
+
 
 @SpringBootApplication
 class Karavan
@@ -19,26 +26,79 @@ fun main(args: Array<String>) {
 @RequestMapping("/wallet")
 class WalletController(val walletService: WalletService) {
 
-    // TODO remove this example
-    @GetMapping("/hello/{name}")
-    fun hello(@PathVariable name: String): String {
-        val descriptor = "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)"
-        val db = DatabaseConfig.Memory("")
-
-        val client =
-            BlockchainConfig.Electrum(
-                ElectrumConfig("ssl://electrum.blockstream.info:60002", null, 5u, null, 10u)
-            )
-        val wallet = OnlineWallet(descriptor, null, Network.TESTNET, db, client)
-        val newAddress = wallet.getNewAddress()
-        return "hello $name, your new address is $newAddress"
+    // Open Wallet by storing the wallet payload in a browser session cookie
+    @PutMapping
+    fun openWallet(response: HttpServletResponse, request: HttpServletRequest, @RequestBody payload: Wallet): String? {
+        // stores payload of type wallet into a cookie on the client's side
+        setCookie(response, payload)
+        // read cookie with key 'wallet' to confirm value
+        return readAllCookies(request)
     }
 
-    @PutMapping("/open_wallet")
-    fun openWallet(response: HttpServletResponse, request: HttpServletRequest, @RequestBody payload: Wallet): String? {
+    // Close wallet by dropping existing descriptor cookie by setting max-age to 0
+    @DeleteMapping
+    fun closeWallet(request: HttpServletRequest?): String?{
 
-        walletService.openWallet(response, payload)
-        return walletService.readCookie(request, "wallet")
+        val cookie = WebUtils.getCookie(request!!, "descriptor")
+        return if (cookie != null) {
+            cookie.maxAge = 0
+            "Wallet is Closed!"
+        } else {
+            "Wallet not found!"
+        }
+    }
+
+    // Get the wallet's balance
+    // Use the browser cookie to get the network and descriptor and then sync
+    // the wallet and get_balance. Will return a balance json with the balance amount.
+    @GetMapping("/getBalance")
+    fun getBalance(request: HttpServletRequest): String{
+
+        // Retrieve wallet cookies and check if they are null before we proceed
+        val descCookie = WebUtils.getCookie(request, "descriptor")
+        val networkCookie = WebUtils.getCookie(request, "network")
+
+        if (descCookie == null || networkCookie == null){
+            return "Wallet cookie not found or corrupted."
+        }
+
+        val descriptor = descCookie.value
+        val network = networkCookie.value
+
+        return walletService.getBalance(descriptor, network)
+    }
+
+    // Store wallet object into client's cookie session
+    fun setCookie(response: HttpServletResponse, walletIn: Wallet) {
+
+        // create cookie key-value pairs for every wallet data member and set HTTP Only property to true
+        for (dataMember in Wallet::class.memberProperties) {
+            val cookie = Cookie(dataMember.name, dataMember.get(walletIn) as String?)
+            cookie.isHttpOnly = true
+            response.addCookie(cookie)
+        }
+    }
+
+    // Read a single cookie value based on key input
+    fun readCookie(request: HttpServletRequest?, key: String): String? {
+        val cookie = WebUtils.getCookie(request!!, key)
+        return if (cookie != null) {
+            "Wallet value is ${cookie.value}"
+        } else {
+            "Wallet not found!"
+        }
+    }
+
+    // Read all cookie inside the client's web session
+    fun readAllCookies(request: HttpServletRequest?): String? {
+
+        val cookies = request!!.cookies
+        return if (cookies != null) {
+            Arrays.stream(cookies)
+                .map { c -> c.getName() + "=" + c.getValue() }.collect(Collectors.joining(", "))
+        } else {
+            "No cookies"
+        }
     }
 
 }

--- a/src/main/kotlin/org/bitcoindevkit/karavan/Wallet.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/Wallet.kt
@@ -1,0 +1,8 @@
+package org.bitcoindevkit.karavan
+
+data class Wallet (
+    val network: String?,
+    val descriptor: String?
+)
+
+

--- a/src/main/kotlin/org/bitcoindevkit/karavan/WalletService.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/WalletService.kt
@@ -16,25 +16,35 @@ import org.bitcoindevkit.*
 @Service
 class WalletService {
 
+    // Create null object of type BdkProgress
+    // update() function is changed to do nothing
+    object NullProgress : BdkProgress {
+        override fun update(progress: Float, message: String?) {}
+    }
+
+
+    // Connect to Electrum network, sync wallet, and return balance as JSON
     fun getBalance(descriptor: String, networkIn: String): String{
 
         val db = DatabaseConfig.Memory("")
         val network : Network
         val balance : ULong
 
+        // Check if valid network
         if (networkIn.equals("TESTNET", ignoreCase = true))
             network = Network.TESTNET
         else
             return "Invalid Network: $networkIn!"
 
+        // Connecting to Electrum network
         val client =
             BlockchainConfig.Electrum(
                 ElectrumConfig("ssl://electrum.blockstream.info:60002", null, 5u, null, 10u)
             )
         val wallet = OnlineWallet(descriptor, null, network, db, client)
 
-        // Cannot find good docs on bdk:sync function, find out what parameters are needed
-        //wallet.sync(progressUpdate = BdkProgress.?, maxAddressParam = ?)
+        // Sync balance of descriptor
+        wallet.sync(progressUpdate = NullProgress, maxAddressParam = null)
 
         // get the balance
         balance = wallet.getBalance()
@@ -48,11 +58,11 @@ class WalletService {
         return balanceJSONString
     }
 
+    // Return wallet object as JSON
     fun WalletToJSON(walletIn: Wallet): String{
         val mapper = jacksonObjectMapper()
         var jsonStr : String = mapper.writeValueAsString(walletIn)
         return jsonStr
     }
-
 
 }

--- a/src/main/kotlin/org/bitcoindevkit/karavan/WalletService.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/WalletService.kt
@@ -1,5 +1,7 @@
 package org.bitcoindevkit.karavan
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import org.springframework.stereotype.Service
 import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
@@ -7,31 +9,50 @@ import org.springframework.web.util.WebUtils
 import javax.servlet.http.Cookie
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import com.fasterxml.jackson.module.kotlin.*
+import org.bitcoindevkit.*
 
 
 @Service
 class WalletService {
 
-    fun openWallet(response: HttpServletResponse, walletIn: Wallet){
-        setCookie(response, walletIn)
+    fun getBalance(descriptor: String, networkIn: String): String{
+
+        val db = DatabaseConfig.Memory("")
+        val network : Network
+        val balance : ULong
+
+        if (networkIn.equals("TESTNET", ignoreCase = true))
+            network = Network.TESTNET
+        else
+            return "Invalid Network: $networkIn!"
+
+        val client =
+            BlockchainConfig.Electrum(
+                ElectrumConfig("ssl://electrum.blockstream.info:60002", null, 5u, null, 10u)
+            )
+        val wallet = OnlineWallet(descriptor, null, network, db, client)
+
+        // Cannot find good docs on bdk:sync function, find out what parameters are needed
+        //wallet.sync(progressUpdate = BdkProgress.?, maxAddressParam = ?)
+
+        // get the balance
+        balance = wallet.getBalance()
+
+        // put balance into JSON and return it
+        val mapper = ObjectMapper()
+        val balanceJSON: ObjectNode = mapper.createObjectNode()
+        balanceJSON.put("balance", balance.toString())
+        val balanceJSONString = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(balanceJSON)
+
+        return balanceJSONString
     }
 
-    fun setCookie(response: HttpServletResponse, walletIn: Wallet) {
-        // create a cookie
-        val cookie = Cookie("wallet", walletIn.descriptor) // might need to change to springframework cookie instead of java
-        cookie.isHttpOnly = true
-
-        //add cookie to response
-        response.addCookie(cookie)
+    fun WalletToJSON(walletIn: Wallet): String{
+        val mapper = jacksonObjectMapper()
+        var jsonStr : String = mapper.writeValueAsString(walletIn)
+        return jsonStr
     }
 
-    fun readCookie(request: HttpServletRequest?, key: String): String? {
-        val cookie = WebUtils.getCookie(request!!, key)
-        return if (cookie != null) {
-            "Wallet value is ${cookie.value}"
-        } else {
-            "Wallet not found!"
-        }
-    }
 
 }

--- a/src/main/kotlin/org/bitcoindevkit/karavan/WalletService.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/WalletService.kt
@@ -1,0 +1,37 @@
+package org.bitcoindevkit.karavan
+
+import org.springframework.stereotype.Service
+import org.springframework.web.bind.annotation.CookieValue
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.util.WebUtils
+import javax.servlet.http.Cookie
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+
+@Service
+class WalletService {
+
+    fun openWallet(response: HttpServletResponse, walletIn: Wallet){
+        setCookie(response, walletIn)
+    }
+
+    fun setCookie(response: HttpServletResponse, walletIn: Wallet) {
+        // create a cookie
+        val cookie = Cookie("wallet", walletIn.descriptor) // might need to change to springframework cookie instead of java
+        cookie.isHttpOnly = true
+
+        //add cookie to response
+        response.addCookie(cookie)
+    }
+
+    fun readCookie(request: HttpServletRequest?, key: String): String? {
+        val cookie = WebUtils.getCookie(request!!, key)
+        return if (cookie != null) {
+            "Wallet value is ${cookie.value}"
+        } else {
+            "Wallet not found!"
+        }
+    }
+
+}

--- a/src/main/kotlin/org/bitcoindevkit/karavan/api.http
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/api.http
@@ -10,6 +10,8 @@ Content-Type: application/json
 ###
 DELETE http://localhost:8080/wallet
 
+###
+GET http://localhost:8080/wallet/getBalance
 
 
 

--- a/src/main/kotlin/org/bitcoindevkit/karavan/api.http
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/api.http
@@ -1,7 +1,29 @@
-PUT http://localhost:8080/wallet/open_wallet
+###
+PUT http://localhost:8080/wallet
 Content-Type: application/json
 
 {
   "network": "testnet",
   "descriptor": "wpkh([1f44db3b/84'/1'/0'/0]tpubDEtS2joSaGheeVGuopWunPzqi7D3BJ9kooggvasZWUzSVziMNKkrdfS7VnLDe6M4Cg6bw3j5oxRB5U7GMJGcFnDia6yUaFAdwWqyJQjn4Qp/0/*)"
 }
+
+###
+DELETE http://localhost:8080/wallet
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Completed implementation for open_wallet request. Inside Karavan.kt is where the api calls are being made. They call on functions inisde WalletService.kt to process those requests. Added files Wallet.kt as the data class and WalletService.kt as the service class for the Wallet data object. Inside WalletService.kt, the function openWallet calls on setCookie that stores the wallet descriptor inside a session cookie on the client's side. readCookie is also called from Karavan.kt to confirm that the cookie was written. 

Please run this request locally to confirm implementation:
````
PUT http://localhost:8080/wallet/open_wallet
Content-Type: application/json

{
"network": "testnet",
"descriptor": "wpkh([1f44db3b/84'/1'/0'/0]tpubDEtS2joSaGheeVGuopWunPzqi7D3BJ9kooggvasZWUzSVziMNKkrdfS7VnLDe6M4Cg6bw3j5oxRB5U7GMJGcFnDia6yUaFAdwWqyJQjn4Qp/0/*)"
}
````

You can run this locally on IntelliJ using an http request file (.http) or using postman.