### PR TITLE
Cookie scope, properly dropping cookie, and edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,24 @@ Bitcoin multisig coordination software
 ./gradlew bootRun
 ```
 
-## Run an example API that uses a bdk wallet after starting the server
+## Run API request to open wallet
 ```shell
-curl -i -X GET http://localhost:8080/wallet/hello/yourname
+curl -j -b /tmp/cookie-jar.txt -c /tmp/cookie-jar.txt -X PUT --location "http://localhost:8080/wallet" \
+    -H "Content-Type: application/json" \
+    -d "{
+          \"network\": \"testnet\",
+          \"descriptor\": \"wpkh([1f44db3b/84'/1'/0'/0]tpubDEtS2joSaGheeVGuopWunPzqi7D3BJ9kooggvasZWUzSVziMNKkrdfS7VnLDe6M4Cg6bw3j5oxRB5U7GMJGcFnDia6yUaFAdwWqyJQjn4Qp/0/*)\"
+        }"
+```
+
+## Run API request to get balance of wallet
+```shell
+curl -b /tmp/cookie-jar.txt -X GET --location "http://localhost:8080/wallet/balance"
+```
+
+## Run API request to close wallet
+```shell
+curl -b /tmp/cookie-jar.txt -c /tmp/cookie-jar.txt -X DELETE --location "http://localhost:8080/wallet"
 ```
 
 ## Run test scripts

--- a/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
@@ -31,7 +31,7 @@ class WalletController(val walletService: WalletService) {
     fun openWallet(response: HttpServletResponse, request: HttpServletRequest, @RequestBody payload: Wallet): String? {
         // stores payload of type wallet into a cookie on the client's side
         setCookie(response, payload)
-        return "Wallet is opened!"
+        return "Wallet is opened!\n"
     }
 
     // Close wallet by dropping existing descriptor cookie
@@ -40,10 +40,10 @@ class WalletController(val walletService: WalletService) {
 
         val cookie = WebUtils.getCookie(request!!, "descriptor")
         return if (cookie == null) {
-            "Wallet not found!"
+            "Wallet not found!\n"
         }
         else if(cookie.value.isNullOrEmpty()){
-            "Wallet already closed!"
+            "Wallet already closed!\n"
         }
         else {
             // In order to delete a cookie, we must replicate it, set its maxAge to 0 and add it to response
@@ -52,7 +52,7 @@ class WalletController(val walletService: WalletService) {
             cookieReplacement.isHttpOnly = true
             cookie.maxAge = 0
             response.addCookie(cookieReplacement)
-            "Wallet is closed!"
+            "Wallet is closed!\n"
         }
     }
 
@@ -68,18 +68,18 @@ class WalletController(val walletService: WalletService) {
 
         // check if cookies are null
         if (descCookie == null || networkCookie == null){
-            return "Wallet not found."
+            return "Wallet not found.\n"
         }
         // check if cookie values are dropped
         if (descCookie.value.isNullOrEmpty() || networkCookie.value.isNullOrEmpty()){
-            return "Wallet is closed, cannot get balance!"
+            return "Wallet is closed, cannot get balance!\n"
         }
 
         val descriptor = descCookie.value
         val network = networkCookie.value
 
         // Call getBalance from WalletService class to process logic and return balance JSON
-        return walletService.getBalance(descriptor, network)
+        return walletService.getBalance(descriptor, network) + "\n"
     }
 
     // Store wallet object into client's cookie session
@@ -100,9 +100,9 @@ class WalletController(val walletService: WalletService) {
     fun readCookie(request: HttpServletRequest?, key: String): String? {
         val cookie = WebUtils.getCookie(request!!, key)
         return if (cookie != null) {
-            "Wallet value is ${cookie.value}"
+            "Wallet value is ${cookie.value}\n"
         } else {
-            "Wallet not found!"
+            "Wallet not found!\n"
         }
     }
 
@@ -114,7 +114,7 @@ class WalletController(val walletService: WalletService) {
             Arrays.stream(cookies)
                 .map { c -> c.getName() + "=" + c.getValue() }.collect(Collectors.joining(", "))
         } else {
-            "No cookies"
+            "No cookies\n"
         }
     }
 

--- a/src/main/kotlin/org/bitcoindevkit/karavan/WalletService.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/WalletService.kt
@@ -43,7 +43,7 @@ class WalletService {
             )
         val wallet = OnlineWallet(descriptor, null, network, db, client)
 
-        // Sync balance of descriptor
+        // sync balance of descriptor
         wallet.sync(progressUpdate = NullProgress, maxAddressParam = null)
 
         // get the balance

--- a/src/main/kotlin/org/bitcoindevkit/karavan/api.http
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/api.http
@@ -1,4 +1,11 @@
 ###
+curl -j -b /tmp/cookie-jar.txt -c /tmp/cookie-jar.txt -X PUT --location "http://localhost:8080/wallet" \
+    -H "Content-Type: application/json" \
+    -d "{
+          \"network\": \"testnet\",
+          \"descriptor\": \"wpkh([1f44db3b/84'/1'/0'/0]tpubDEtS2joSaGheeVGuopWunPzqi7D3BJ9kooggvasZWUzSVziMNKkrdfS7VnLDe6M4Cg6bw3j5oxRB5U7GMJGcFnDia6yUaFAdwWqyJQjn4Qp/0/*)\"
+        }"
+###
 PUT http://localhost:8080/wallet
 Content-Type: application/json
 
@@ -8,10 +15,18 @@ Content-Type: application/json
 }
 
 ###
+curl -b /tmp/cookie-jar.txt -c /tmp/cookie-jar.txt -X DELETE --location "http://localhost:8080/wallet"
+###
 DELETE http://localhost:8080/wallet
 
 ###
+curl -b /tmp/cookie-jar.txt -X GET --location "http://localhost:8080/wallet/balance"
+###
 GET http://localhost:8080/wallet/balance
+
+
+
+
 
 
 


### PR DESCRIPTION
Set scope of cookies to the correct path /wallet instead of /, and added comments to code.

Update: 
Pushed a second commit to fix closeWallet implementation. Setting maxAge of cookie to 0 alone does not do it, we must replicate the cookie, set its maxAge to 0, and then add it to response. Also added checks for edge cases for getBalance and closeWallet. Primarily, user cannot close a wallet that does not exist or call getBalance on a closed wallet, or a wallet that does not exist.

