### PR TITLE
Get Transactions API Request

### DIFF
--- a/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/Karavan.kt
@@ -54,25 +54,6 @@ class WalletController(val walletService: WalletService) {
         }
     }
 
-    @GetMapping("/address/new")
-    fun getNewAddress(request: HttpServletRequest): String{
-
-        // Retrieve wallet cookies
-        val descCookie = WebUtils.getCookie(request, "descriptor")
-        val networkCookie = WebUtils.getCookie(request, "network")
-
-        // check if cookies are null or dropped
-        if (descCookie == null || networkCookie == null || descCookie.value.isNullOrEmpty() || networkCookie.value.isNullOrEmpty()){
-            return "Wallet not found.\n"
-        }
-
-        val descriptor = descCookie.value
-        val network = networkCookie.value
-
-        // Call getNewAddress function and return a new address in string format.
-        return walletService.getNewAddress(descriptor, network) + "\n"
-    }
-
     // Get the wallet's balance
     // Use the browser cookie to get the network and descriptor and then syncing wallet
     // return a balance json with the balance amount.
@@ -93,6 +74,44 @@ class WalletController(val walletService: WalletService) {
 
         // Call getBalance from WalletService class to process logic and return balance JSON
         return walletService.getBalance(descriptor, network) + "\n"
+    }
+
+    @GetMapping("/address/new")
+    fun getNewAddress(request: HttpServletRequest): String{
+
+        // Retrieve wallet cookies
+        val descCookie = WebUtils.getCookie(request, "descriptor")
+        val networkCookie = WebUtils.getCookie(request, "network")
+
+        // check if cookies are null or dropped
+        if (descCookie == null || networkCookie == null || descCookie.value.isNullOrEmpty() || networkCookie.value.isNullOrEmpty()){
+            return "Wallet not found.\n"
+        }
+
+        val descriptor = descCookie.value
+        val network = networkCookie.value
+
+        // Call getNewAddress function and return a new address in string format.
+        return walletService.getNewAddress(descriptor, network) + "\n"
+    }
+
+    @GetMapping("/transactions")
+    fun getTransactions(request: HttpServletRequest): String{
+
+        // Retrieve wallet cookies
+        val descCookie = WebUtils.getCookie(request, "descriptor")
+        val networkCookie = WebUtils.getCookie(request, "network")
+
+        // check if cookies are null or dropped
+        if (descCookie == null || networkCookie == null || descCookie.value.isNullOrEmpty() || networkCookie.value.isNullOrEmpty()){
+            return "Wallet not found.\n"
+        }
+
+        val descriptor = descCookie.value
+        val network = networkCookie.value
+
+        // Call getTransactions from WalletService class to process logic and return list of transactions in JSON format
+        return walletService.getTransactions(descriptor, network) + "\n"
     }
 
     // Store wallet object into client's cookie session

--- a/src/main/kotlin/org/bitcoindevkit/karavan/api.http
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/api.http
@@ -24,8 +24,15 @@ curl -b /tmp/cookie-jar.txt -X GET --location "http://localhost:8080/wallet/bala
 ###
 GET http://localhost:8080/wallet/balance
 
+###
+curl -b /tmp/cookie-jar.txt -X GET --location "http://localhost:8080/wallet/balance"
+###
+GET http://localhost:8080/wallet/address/new
 
-
+###
+curl -b /tmp/cookie-jar.txt -X GET --location "http://localhost:8080/wallet/transactions"
+###
+GET http://localhost:8080/wallet/transactions
 
 
 

--- a/src/main/kotlin/org/bitcoindevkit/karavan/api.http
+++ b/src/main/kotlin/org/bitcoindevkit/karavan/api.http
@@ -25,7 +25,7 @@ curl -b /tmp/cookie-jar.txt -X GET --location "http://localhost:8080/wallet/bala
 GET http://localhost:8080/wallet/balance
 
 ###
-curl -b /tmp/cookie-jar.txt -X GET --location "http://localhost:8080/wallet/balance"
+curl -b /tmp/cookie-jar.txt -X GET --location "http://localhost:8080/wallet/address/new"
 ###
 GET http://localhost:8080/wallet/address/new
 


### PR DESCRIPTION
Completed implementation of the GET .../wallet/transactions API request. Function returns a json formatted list of transactions associated with descriptor.

In order to test:

```
1. Run server, open wallet, get address, and copy the address
2. Go to https://bitcoinfaucet.uo1.net/ and paste address, and send a small amount.
3. Go to https://mempool.space/testnet and paste the address in the top right search bar and review the transactions 
4. Go back to your client and run the GET http://localhost:8080/wallet/transactions through postman, api.http file, or the curl command provided in the api.http file (make sure you also open the wallet using curl).
5. After running request, you should receive back a list of transactions in JSON, you can also run the .../wallet/balance request to check the updated balance.
```

Also updated api.http to have all new api requests.

This PR closes #12 
